### PR TITLE
update links to rust sdk, js sdk docs, and hyperdocs

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -46,7 +46,7 @@ export function Footer() {
               <li>
                 <a
                   className="hover:text-neutral-100 transition-all"
-                  href="https://docs-delv.gitbook.io/hyperdrive/hyperdrive-overview/ui-walkthrough"
+                  href="https://docs.hyperdrive.box/hyperdrive-overview/ui-walkthrough"
                 >
                   User Guides
                 </a>

--- a/src/components/build/CodeTabs.tsx
+++ b/src/components/build/CodeTabs.tsx
@@ -194,7 +194,7 @@ export function CodeTabs() {
               to move the pool to a target rate, and much more.
             </p>
             <GradientBorderButton
-              href="https://github.com/delvtech/hyperdrive/tree/main/crates/hyperdrive-math"
+              href="https://github.com/delvtech/hyperdrive-rs"
               className="button-sm"
             >
               Rust SDK source code
@@ -393,7 +393,7 @@ close_long_event = hyperdrive_agent0.close_long(
               Math library compiled to WebAssembly.
             </p>
             <GradientBorderButton
-              href="https://hyperdrive-js.delv.tech"
+              href="https://js.hyperdrive.box"
               className="button-sm"
             >
               TypeScript SDK Docs

--- a/src/pages/Build.tsx
+++ b/src/pages/Build.tsx
@@ -142,7 +142,7 @@ export function Build() {
             <li>
               <a
                 className="hover:text-aquamarine transition-all"
-                href="https://github.com/delvtech/hyperdrive/tree/main/crates/hyperdrive-math"
+                href="https://github.com/delvtech/hyperdrive-rs"
               >
                 Rust SDK
               </a>
@@ -150,7 +150,7 @@ export function Build() {
             <li>
               <a
                 className="hover:text-aquamarine transition-all"
-                href="https://hyperdrive-js.delv.tech/"
+                href="https://js.hyperdrive.box"
               >
                 TypeScript SDK
               </a>

--- a/src/pages/FAQs.tsx
+++ b/src/pages/FAQs.tsx
@@ -142,7 +142,7 @@ export function FAQs() {
                 available markets where you can take a Long, Short, and/or LP
                 position to engage in passive or active yield strategies. Find
                 more details in our{" "}
-                <a href="https://docs-delv.gitbook.io/hyperdrive/hyperdrive-overview/ui-walkthrough">
+                <a href="https://docs.hyperdrive.box/hyperdrive-overview/ui-walkthrough">
                   UI Walkthrough
                 </a>
                 .
@@ -164,7 +164,7 @@ export function FAQs() {
 
             <Answer question="What are Longs & Shorts?">
               <p>
-                <a href="https://docs-delv.gitbook.io/hyperdrive/hyperdrive-overview/position-types/longs-fixed-rates">
+                <a href="https://docs.hyperdrive.box/hyperdrive-overview/position-types/longs-fixed-rates">
                   Long positions
                 </a>{" "}
                 in Hyperdrive allow users to earn a fixed rate on their
@@ -179,7 +179,7 @@ export function FAQs() {
                 1.05 stETH one year from now.
               </p>
               <p>
-                <a href="https://docs-delv.gitbook.io/hyperdrive/hyperdrive-overview/position-types/shorts-variable-rates">
+                <a href="https://docs.hyperdrive.box/hyperdrive-overview/position-types/shorts-variable-rates">
                   Short positions
                 </a>{" "}
                 in Hyperdrive enable users to earn a multiplied variable rate
@@ -221,7 +221,7 @@ export function FAQs() {
 
             <Answer question="What is the role of a Liquidity Provider?">
               <p>
-                <a href="https://docs-delv.gitbook.io/hyperdrive/hyperdrive-overview/position-types/liquidity-provider">
+                <a href="https://docs.hyperdrive.box/hyperdrive-overview/position-types/liquidity-provider">
                   Liquidity Providers
                 </a>{" "}
                 (LPs) deposit single-sided liquidity into the Hyperdrive AMM,
@@ -291,7 +291,7 @@ export function FAQs() {
             <Answer question="Are there any fees?">
               <p>
                 Users pay two types of{" "}
-                <a href="https://docs-delv.gitbook.io/hyperdrive/trading/fees">
+                <a href="https://docs.hyperdrive.box/trading/fees">
                   fees
                 </a>{" "}
                 when opening or closing their Long or Short positions:
@@ -332,7 +332,7 @@ export function FAQs() {
 
             <Answer question="What is a Fixed Rate Borrow Position?">
               <p>
-                <a href="https://docs-delv.gitbook.io/hyperdrive/trading/trading-strategies/fixed-rate-borrow">
+                <a href="https://docs.hyperdrive.box/trading/trading-strategies/fixed-rate-borrow">
                   Fixed Rate Borrow
                 </a>{" "}
                 is a feature unlocked by Hyperdrive markets that allows users to

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -323,7 +323,7 @@ export function Home() {
 
         <div className="flex items-center justify-center">
           <GradientBorderButton
-            href="https://docs-delv.gitbook.io/hyperdrive/hyperdrive-overview/position-types/liquidity-provider"
+            href="https://docs.hyperdrive.box/hyperdrive-overview/position-types/liquidity-provider"
             className="button-primary"
           >
             Learn more


### PR DESCRIPTION
* Fix Rust SDK links which pointed to the old location (hyperdrive/crates/hyperdrive-math)
* Update JS SDK links to point to js.hyperdrive.box domain
* Update docs links to point to docs.hyperdrive.box domain